### PR TITLE
Configure WebClient to use custom asset deserializer

### DIFF
--- a/src/main/java/com/example/demo/WebClientConfiguration.java
+++ b/src/main/java/com/example/demo/WebClientConfiguration.java
@@ -1,7 +1,10 @@
 package com.example.demo;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -11,9 +14,14 @@ public class WebClientConfiguration {
     @Bean
     public WebClient externalApiWebClient(WebClient.Builder builder,
                                           ExternalApiProperties properties,
-                                          ExternalApiMockServer externalApiMockServer) {
+                                          ExternalApiMockServer externalApiMockServer,
+                                          ObjectMapper objectMapper) {
         ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .codecs(configurer -> {
+                    configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024);
+                    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
+                    configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(objectMapper));
+                })
                 .build();
 
         return builder


### PR DESCRIPTION
## Summary
- configure the external API WebClient to use the application ObjectMapper that includes the asset polymorphism module
- keep the existing memory limits while wiring the Jackson encoder and decoder for the WebClient

## Testing
- ./gradlew test *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e17bace4832995559f6fb06203be